### PR TITLE
fix typo in doc of \xmathstrut

### DIFF
--- a/mathtools.dtx
+++ b/mathtools.dtx
@@ -2755,7 +2755,7 @@ colorlinks,
 %      \verb|\xmathstrut{0.1}| 
 %  \end{center}
 %  will give you a new strut where 10\% of the \emph{total height of
-%  the normal math stut} (\verb|\mathstrut=\mathstrut{0}|) will be
+%  the normal math stut} (\verb|\mathstrut=\xmathstrut{0}|) will be
 %  added to both \emph{the height} and \emph{the depth} of the
 %  original strut (thus 20\% gets added in total). On the other hand
 %  \begin{center}
@@ -2816,7 +2816,7 @@ colorlinks,
 % \]
 % \end{verbatim}
 % -- the last box showcases a strut where we have only changed the
-% depth of the strut. One can see \verb|\xmathstrut[B]{0}| kind of the
+% depth of the strut. One can see \verb|\xmathstrut[0.5]{0}| kind of the
 % opposite of \verb|\smash[b]{...}|, the former makes the depth larger
 % and the latter ignores the depth.
 %


### PR DESCRIPTION
Main changes:
 - Change `\mathstrut=\mathstrut{0}` to `\mathstrut=\xmathstrut{0}`
 - Change `\xmathstrut[B]{0} ... \smash[b]{...}` to `\xmathstrut[0.5]{0} ... \smash[b]{...}`, since 1) the optional argument of `\xmathstrut` accepts decimal only, and 2) the nearest example is `\xmathstrut[0.5]{0}`.