### PR TITLE
Improve the manual slightly

### DIFF
--- a/mathtools.dtx
+++ b/mathtools.dtx
@@ -2040,9 +2040,9 @@ colorlinks,
 %     \cs{delimsize}
 %  \end{codesyntax}
 %  Sometimes one might want to have the capabilities of
-%  \cs{DeclarePairedDelimiter}, but also want a macro the takes more
-%  than one argument and specify plus being able to specify the body
-%  of the generated macro. 
+%  \cs{DeclarePairedDelimiter}, but also want a macro which takes more
+%  than one argument plus being able to specify the body of the
+%  generated macro.
 %
 %  \cs{DeclarePairedDelimiterX} extends the features of
 %  \cs{DeclarePairedDelimiter} such that the user will get a macro
@@ -2783,7 +2783,7 @@ colorlinks,
 %    \SpecialUsageIndex{\splitdfrac}\cs{splitdfrac}\marg{start line}\marg{continuation}
 %  \end{codesyntax}
 %  \cttPosting{Michael J.~Downes}{2001/12/06}
-%  These commands provide split fractions e.g., multiline fractions:
+%  These commands provide split fractions, e.g., multiline fractions:
 %  \begin{verbatim}
 %    \[
 %      a=\frac{


### PR DESCRIPTION
* mathtools.dtx (subsection{Paired delimiters}): Slightly rephrase the description.
(subsection{Split fractions}): Add a comma before 'e.g'.