### PR TITLE
Fix typo in mathtools.dtx

### DIFF
--- a/mathtools.dtx
+++ b/mathtools.dtx
@@ -2198,8 +2198,8 @@ colorlinks,
 % the \marg{pre code} and \marg{post code} it is identical to
 % \cs{DeclarePairedDelimiterX}. It should be interpreted as
 % \begin{center}
-% \marg{pre code} \marg{left_delim} \marg{body}
-% \marg{right_delim} \marg{post code}  
+% \marg{pre code} \marg{left_delim} \marg{right_delim}
+% \marg{post code} \marg{body}
 % \end{center}
 % 
 %


### PR DESCRIPTION
It has come to my attention that there was a mix-up in the ordering for interpreting arguments w.r.t. `\DeclarePairedDelimiterXPP` in the documentation.

The PR corrects this.