### PR TITLE
typo

### DIFF
--- a/mathtools.dtx
+++ b/mathtools.dtx
@@ -1185,7 +1185,7 @@ colorlinks,
 %   A & \xlongrightarrow[b]{a} B & A & \xlongleftarrow[b]{a} B \\
 %   A & \xlongrightarrow[below]{above} B & A & \xlongleftarrow[below]{above} B \\
 % \end{align*}
-%%  \begin{codesyntax}
+%  \begin{codesyntax}
 %    \SpecialUsageIndex{\xLongrightarrow}
 %    \cs{xLongrightarrow}\oarg{sub}\marg{sup}\texttt{~~~~}
 %    \SpecialUsageIndex{\xLongleftarrow}
@@ -7048,5 +7048,5 @@ colorlinks,
 %</package>
 %    \end{macrocode}
 %
-%  \ Finale
+%  \Finale
 \endinput


### PR DESCRIPTION
Correct two typos introduced in 2636c4a (typo, 2024-01-18) and 7fd80d2 (Added \xLongleftarrow and \xLongrightarrow as requested in #<span></span>51, 2024-01-18), correspondingly.